### PR TITLE
解超长request中英文混用报错问题

### DIFF
--- a/libs/kotaemon/kotaemon/indices/vectorindex.py
+++ b/libs/kotaemon/kotaemon/indices/vectorindex.py
@@ -184,6 +184,8 @@ class VectorRetrieval(BaseRetrieval):
             docs = self.doc_store.query(query, top_k=top_k_first_round, doc_ids=scope)
             result = [RetrievedDocument(**doc.to_dict(), score=-1.0) for doc in docs]
         elif self.retrieval_mode == "hybrid":
+            
+            print("Starting hybrid retrieval...")
             # similarity search section
             emb = self.embedding(text)[0].embedding
             vs_docs: list[RetrievedDocument] = []
@@ -223,83 +225,101 @@ class VectorRetrieval(BaseRetrieval):
             vs_query_thread.join()
             ds_query_thread.join()
 
+       
             result = [
                 RetrievedDocument(**doc.to_dict(), score=-1.0)
                 for doc in ds_docs
                 if doc not in vs_ids
             ]
+
+            print('len_result_ds_docs:',len(result))
+
             result += [
                 RetrievedDocument(**doc.to_dict(), score=score)
                 for doc, score in zip(vs_docs, vs_scores)
             ]
+            print('len_result_vs_docs+ds_docs:',len(result))
+
             print(f"Got {len(vs_docs)} from vectorstore")
             print(f"Got {len(ds_docs)} from docstore")
+        return result
+        
 
         # use additional reranker to re-order the document list
-        if self.rerankers and text:
-            for reranker in self.rerankers:
-                # if reranker is LLMReranking, limit the document with top_k items only
-                if isinstance(reranker, LLMReranking):
-                    result = self._filter_docs(result, top_k=top_k)
-                result = reranker.run(documents=result, query=text)
+        # if self.rerankers and text:
+        #     for reranker in self.rerankers:
+        #         # if reranker is LLMReranking, limit the document with top_k items only
+        #         if isinstance(reranker, LLMReranking):
+        #             result = self._filter_docs(result, top_k=top_k)
+        #             print('len_resultisinstance:',len(result))
 
-        result = self._filter_docs(result, top_k=top_k)
-        print(f"Got raw {len(result)} retrieved documents")
+        #         result = reranker.run(documents=result, query=text)
+        #         print('len_result_rerank:',len(result))
 
-        # add page thumbnails to the result if exists
-        thumbnail_doc_ids: set[str] = set()
-        # we should copy the text from retrieved text chunk
-        # to the thumbnail to get relevant LLM score correctly
-        text_thumbnail_docs: dict[str, RetrievedDocument] = {}
 
-        non_thumbnail_docs = []
-        raw_thumbnail_docs = []
-        for doc in result:
-            if doc.metadata.get("type") == "thumbnail":
-                # change type to image to display on UI
-                doc.metadata["type"] = "image"
-                raw_thumbnail_docs.append(doc)
-                continue
-            if (
-                "thumbnail_doc_id" in doc.metadata
-                and len(thumbnail_doc_ids) < thumbnail_count
-            ):
-                thumbnail_id = doc.metadata["thumbnail_doc_id"]
-                thumbnail_doc_ids.add(thumbnail_id)
-                text_thumbnail_docs[thumbnail_id] = doc
-            else:
-                non_thumbnail_docs.append(doc)
+        # result = self._filter_docs(result, top_k=top_k)
+        # print('len_result_rerank:',len(result))
 
-        linked_thumbnail_docs = self.doc_store.get(list(thumbnail_doc_ids))
-        print(
-            "thumbnail docs",
-            len(linked_thumbnail_docs),
-            "non-thumbnail docs",
-            len(non_thumbnail_docs),
-            "raw-thumbnail docs",
-            len(raw_thumbnail_docs),
-        )
-        additional_docs = []
+        # print(f"Got raw {len(result)} retrieved documents")
 
-        for thumbnail_doc in linked_thumbnail_docs:
-            text_doc = text_thumbnail_docs[thumbnail_doc.doc_id]
-            doc_dict = thumbnail_doc.to_dict()
-            doc_dict["_id"] = text_doc.doc_id
-            doc_dict["content"] = text_doc.content
-            doc_dict["metadata"]["type"] = "image"
-            for key in text_doc.metadata:
-                if key not in doc_dict["metadata"]:
-                    doc_dict["metadata"][key] = text_doc.metadata[key]
+        # # add page thumbnails to the result if exists
+        # thumbnail_doc_ids: set[str] = set()
+        # # we should copy the text from retrieved text chunk
+        # # to the thumbnail to get relevant LLM score correctly
+        # text_thumbnail_docs: dict[str, RetrievedDocument] = {}
 
-            additional_docs.append(RetrievedDocument(**doc_dict, score=text_doc.score))
+        # non_thumbnail_docs = []
+        # raw_thumbnail_docs = []
+        # for doc in result:
+        #     if doc.metadata.get("type") == "thumbnail":
+        #         # change type to image to display on UI
+        #         doc.metadata["type"] = "image"
+        #         raw_thumbnail_docs.append(doc)
+        #         continue
+        #     if (
+        #         "thumbnail_doc_id" in doc.metadata
+        #         and len(thumbnail_doc_ids) < thumbnail_count
+        #     ):
+        #         thumbnail_id = doc.metadata["thumbnail_doc_id"]
+        #         thumbnail_doc_ids.add(thumbnail_id)
+        #         text_thumbnail_docs[thumbnail_id] = doc
+        #     else:
+        #         non_thumbnail_docs.append(doc)
 
-        result = additional_docs + non_thumbnail_docs
+        # linked_thumbnail_docs = self.doc_store.get(list(thumbnail_doc_ids))
+        # print(
+        #     "thumbnail docs",
+        #     len(linked_thumbnail_docs),
+        #     "non-thumbnail docs",
+        #     len(non_thumbnail_docs),
+        #     "raw-thumbnail docs",
+        #     len(raw_thumbnail_docs),
+        # )
+        # additional_docs = []
 
-        if not result:
-            # return output from raw retrieved thumbnails
-            result = self._filter_docs(raw_thumbnail_docs, top_k=thumbnail_count)
+        # for thumbnail_doc in linked_thumbnail_docs:
+        #     text_doc = text_thumbnail_docs[thumbnail_doc.doc_id]
+        #     doc_dict = thumbnail_doc.to_dict()
+        #     doc_dict["_id"] = text_doc.doc_id
+        #     doc_dict["content"] = text_doc.content
+        #     doc_dict["metadata"]["type"] = "image"
+        #     for key in text_doc.metadata:
+        #         if key not in doc_dict["metadata"]:
+        #             doc_dict["metadata"][key] = text_doc.metadata[key]
 
-        return result
+        #     additional_docs.append(RetrievedDocument(**doc_dict, score=text_doc.score))
+
+        # result += additional_docs + non_thumbnail_docs
+
+        # print('len_result_second2end:',len(result))
+
+        # if not result:
+        #     # return output from raw retrieved thumbnails
+        #     result = self._filter_docs(raw_thumbnail_docs, top_k=thumbnail_count)
+
+        # print('len_result_end:',len(result))
+
+        # return result
 
 
 class TextVectorQA(BaseComponent):

--- a/libs/kotaemon/kotaemon/llms/chats/openai.py
+++ b/libs/kotaemon/kotaemon/llms/chats/openai.py
@@ -41,6 +41,7 @@ class BaseChatOpenAI(ChatLLM):
     )
     max_tokens: Optional[int] = Param(
         None,
+        # 10000,
         help=(
             "Maximum number of tokens to generate. The total length of input tokens "
             "and generated tokens is limited by the model's context length."

--- a/libs/ktem/ktem/index/file/graph/pipelines.py
+++ b/libs/ktem/ktem/index/file/graph/pipelines.py
@@ -362,7 +362,7 @@ class GraphRAGRetrieverPipeline(BaseFileIndexRetriever):
             "embedding_vectorstore_key": EntityVectorStoreKey.ID,
             # set this to EntityVectorStoreKey.TITLE i
             # f the vectorstore uses entity title as ids
-            "max_tokens": 12_000,
+            "max_tokens": 12000,
             # change this based on the token limit you have on your model
             # (if you are using a model with 8k limit, a good setting could be 5000)
         }


### PR DESCRIPTION
## Description

超长request中英文混用，报错：
![image](https://github.com/user-attachments/assets/0f986840-20c8-4507-8da6-8220b70ece30)
![image](https://github.com/user-attachments/assets/d88a8041-fe1e-4a6f-84c3-1ee9369fa7ec)

问题本质：
搜索不到对应文档

## Type of change

- [ ] New features (non-breaking change).
- [ x] Bug fix (non-breaking change).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).

## Checklist


- [x ] I have commented on my code, particularly in hard-to-understand areas.

报错线索：
Got 100 from vectorstore
Got 0 from docstore

debug时候print('len_result_second2end:',len(result))没有执行，怀疑result被重置了，过程中发现# use additional reranker to re-order the document list之后的语句没有执行，而且还重置了result